### PR TITLE
Fix windows scroll

### DIFF
--- a/main-site/components/past-photos-section/PastPhotosSection.styles.ts
+++ b/main-site/components/past-photos-section/PastPhotosSection.styles.ts
@@ -10,7 +10,7 @@ const StyledPhotosSection = styled.div`
 `;
 
 const StyledPhotos = styled.img`
-  width: 100vw;
+  width: 100%;
 `;
 
 const StyledPastPhotosButton = styled.div`


### PR DESCRIPTION
<Summary line - One sentence describing your intended set of changes>

Fixes #52 

Changelist:

- changed photo width from `100vw` to `100%`.

Notes:

- Seems like this bug only happend on windows. Please try out the site for yourself and see if it is fixed! For example I might have broken something for mac users but I wouldn't have a way to know. The photos section shouldn't overflow horizontally.

Tested:

- Tested locally on firefox and chrome for all resolutions
