### PR TITLE
Update meet the team

### DIFF
--- a/shared-ui/components/meet-the-team/team-column/desktop-team-column/DesktopTeamColumn.styles.ts
+++ b/shared-ui/components/meet-the-team/team-column/desktop-team-column/DesktopTeamColumn.styles.ts
@@ -8,12 +8,13 @@ const StyledTeamColumn = styled.div`
     width: 11em;
   }
   @media ${max.tabletLg} {
-    width: 9.5em;
+    width: clamp(9.5em, 20vw, 11em);
   }
 `;
+
 const StyledHeadshot = styled.img`
   padding-top: 2em;
-  width: 8.5em;
+  width: 9em;
   @media ${max.tabletLg} {
     width: 6.5em;
     margin: 0;

--- a/shared-ui/components/meet-the-team/team-column/desktop-team-column/DesktopTeamColumn.styles.ts
+++ b/shared-ui/components/meet-the-team/team-column/desktop-team-column/DesktopTeamColumn.styles.ts
@@ -3,7 +3,10 @@ import { max } from '../../../../lib/responsive';
 
 const StyledTeamColumn = styled.div`
   flex-direction: column;
-  width: 11em;
+  width: 14em;
+  @media ${max.desktop} {
+    width: 11em;
+  }
   @media ${max.tabletLg} {
     width: 9.5em;
   }

--- a/shared-ui/components/meet-the-team/team-column/desktop-team-column/DesktopTeamColumn.styles.ts
+++ b/shared-ui/components/meet-the-team/team-column/desktop-team-column/DesktopTeamColumn.styles.ts
@@ -1,8 +1,5 @@
 import styled from 'styled-components';
 import { max } from '../../../../lib/responsive';
-import { StyledTeamLabelProps } from '../../../../lib/types';
-import { colors } from '../../../../style/colors';
-import { P } from '../../../../style/typography';
 
 const StyledTeamColumn = styled.div`
   flex-direction: column;
@@ -11,18 +8,6 @@ const StyledTeamColumn = styled.div`
     width: 9.5em;
   }
 `;
-
-const StyledLabel = styled(P)<StyledTeamLabelProps>`
-  padding-left: 0.5em;
-  width: 8em;
-  margin-bottom: ${(props): string => (props.twoLines ? '-1.2em' : '0')};
-  color: ${colors.TEXT_BROWN};
-  letter-spacing: 0.1em;
-  @media ${max.tabletLg} {
-    padding-left: 0;
-  }
-`;
-
 const StyledHeadshot = styled.img`
   padding-top: 2em;
   width: 8.5em;
@@ -41,4 +26,4 @@ const StyledHeadshot = styled.img`
   }
 `;
 
-export { StyledTeamColumn, StyledLabel, StyledHeadshot };
+export { StyledTeamColumn, StyledHeadshot };

--- a/shared-ui/components/meet-the-team/team-column/desktop-team-column/DesktopTeamColumn.tsx
+++ b/shared-ui/components/meet-the-team/team-column/desktop-team-column/DesktopTeamColumn.tsx
@@ -1,20 +1,15 @@
 import React, { useState } from 'react';
 import { Person, TeamColumnProps } from '../../../../lib/types';
+import SecondaryButton from '../../../secondary-button/SecondaryButton';
 import ToolTip from '../../tooltip/ToolTip';
-import {
-  StyledTeamColumn,
-  StyledLabel,
-  StyledHeadshot
-} from './DesktopTeamColumn.styles';
+import { StyledTeamColumn, StyledHeadshot } from './DesktopTeamColumn.styles';
 
 const DesktopTeamColumn: React.FC<TeamColumnProps> = ({ columnInfo }) => {
   const listOfPictures: Person[][] = columnInfo.listOfPictures; // data for each team
   const [curPerson, setCurPerson] = useState<Person | null>(null); // initialized as nothing
   return (
     <StyledTeamColumn>
-      <StyledLabel twoLines={columnInfo.teamLabel == 'Social Outreach'}>
-        {columnInfo.teamLabel}
-      </StyledLabel>
+      <SecondaryButton btnText={columnInfo.teamLabel} isClickable={false} />
       <div>
         {listOfPictures.map((rowPics: Person[]) => (
           <div>

--- a/shared-ui/components/meet-the-team/team-column/mobile-team-column/MobileTeamColumn.styles.ts
+++ b/shared-ui/components/meet-the-team/team-column/mobile-team-column/MobileTeamColumn.styles.ts
@@ -8,7 +8,6 @@ const StyledMobileTeamColumn = styled.div`
 const LabelArrowContainer = styled.div`
   display: flex;
   justify-content: center;
-  padding-right: 0.5em;
 `;
 
 const MobileImageContainer = styled.div`
@@ -32,10 +31,18 @@ const StyledImageRow = styled.div`
   justify-content: center;
 `;
 
+const StyledSecondaryButtonWrapper = styled.div`
+  margin: 0 2em;
+  @media ${max.tabletSm} {
+    margin: 0 1em;
+  }
+`;
+
 export {
   LabelArrowContainer,
   MobileImageContainer,
   StyledMobileTeamColumn,
   StyledImageRow,
-  StyledHeadshot
+  StyledHeadshot,
+  StyledSecondaryButtonWrapper
 };

--- a/shared-ui/components/meet-the-team/team-column/mobile-team-column/MobileTeamColumn.styles.ts
+++ b/shared-ui/components/meet-the-team/team-column/mobile-team-column/MobileTeamColumn.styles.ts
@@ -1,8 +1,5 @@
 import styled from 'styled-components';
 import { max } from '../../../../lib/responsive';
-import { StyledTeamLabelProps } from '../../../../lib/types';
-import { colors } from '../../../../style/colors';
-import { P } from '../../../../style/typography';
 
 const StyledMobileTeamColumn = styled.div`
   padding-top: 2.5em;
@@ -35,26 +32,10 @@ const StyledImageRow = styled.div`
   justify-content: center;
 `;
 
-const StyledLabel = styled(P)<StyledTeamLabelProps>`
-  padding-left: 0.8em;
-  width: 8em;
-  margin-bottom: ${(props): string => (props.twoLines ? '-1.2em' : '0')};
-  font-size: 1.9em;
-  color: ${colors.TEXT_BROWN};
-  letter-spacing: 0.1em;
-  @media ${max.tabletLg} {
-    padding-left: 0;
-  }
-  @media ${max.tabletSm} {
-    font-size: 1.6em;
-  }
-`;
-
 export {
   LabelArrowContainer,
   MobileImageContainer,
   StyledMobileTeamColumn,
   StyledImageRow,
-  StyledHeadshot,
-  StyledLabel
+  StyledHeadshot
 };

--- a/shared-ui/components/meet-the-team/team-column/mobile-team-column/MobileTeamColumn.tsx
+++ b/shared-ui/components/meet-the-team/team-column/mobile-team-column/MobileTeamColumn.tsx
@@ -11,9 +11,9 @@ import {
   LabelArrowContainer,
   MobileImageContainer,
   StyledImageRow,
-  StyledHeadshot,
-  StyledLabel
+  StyledHeadshot
 } from './MobileTeamColumn.styles';
+import SecondaryButton from '../../../secondary-button/SecondaryButton';
 
 const MobileTeamColumn: React.FC<MobileTeamColumnProps> = ({
   listOfColumnInfo
@@ -37,9 +37,7 @@ const MobileTeamColumn: React.FC<MobileTeamColumnProps> = ({
             )
           }
         />
-        <StyledLabel twoLines={curColumn.teamLabel == 'Social Outreach'}>
-          {curColumn.teamLabel}
-        </StyledLabel>
+        <SecondaryButton btnText={curColumn.teamLabel} isClickable={false} />
         <Arrow
           left={false}
           onClick={(): void =>

--- a/shared-ui/components/meet-the-team/team-column/mobile-team-column/MobileTeamColumn.tsx
+++ b/shared-ui/components/meet-the-team/team-column/mobile-team-column/MobileTeamColumn.tsx
@@ -11,7 +11,8 @@ import {
   LabelArrowContainer,
   MobileImageContainer,
   StyledImageRow,
-  StyledHeadshot
+  StyledHeadshot,
+  StyledSecondaryButtonWrapper
 } from './MobileTeamColumn.styles';
 import SecondaryButton from '../../../secondary-button/SecondaryButton';
 
@@ -37,7 +38,9 @@ const MobileTeamColumn: React.FC<MobileTeamColumnProps> = ({
             )
           }
         />
-        <SecondaryButton btnText={curColumn.teamLabel} isClickable={false} />
+        <StyledSecondaryButtonWrapper>
+          <SecondaryButton btnText={curColumn.teamLabel} isClickable={false} />
+        </StyledSecondaryButtonWrapper>
         <Arrow
           left={false}
           onClick={(): void =>

--- a/shared-ui/components/secondary-button/SecondaryButton.styles.ts
+++ b/shared-ui/components/secondary-button/SecondaryButton.styles.ts
@@ -10,11 +10,14 @@ const StyledSecondaryButton = styled.button<StyledSecondaryButtonProps>`
   letter-spacing: 0.1em;
   padding-top: 1em;
   padding-bottom: 1em;
-  width: 10.5em;
+  width: 13em;
   border-radius: 2em;
   border: 2em;
   cursor: ${(props): string => (props.isClickable ? 'pointer' : 'cursor')};
   font-size: 1em;
+  @media ${max.desktop} {
+    width: 10.4em;
+  }
   @media ${max.tabletLg} {
     width: 9.4em;
   }

--- a/shared-ui/components/secondary-button/SecondaryButton.styles.ts
+++ b/shared-ui/components/secondary-button/SecondaryButton.styles.ts
@@ -4,21 +4,24 @@ import { StyledSecondaryButtonProps } from '../../lib/types';
 import { colors } from '../../style/colors';
 
 const StyledSecondaryButton = styled.button<StyledSecondaryButtonProps>`
-  color: ${(props): string => props.isJudgingSecondary ? colors.WHITE : colors.BUTTON_GREEN};
+  color: ${colors.WHITE};
   background-color: ${colors.BUTTON_DARK_GREEN};
-  border-color: ${colors.BUTTON_GREEN};
-  letter-spacing: ${(props): string => props.isJudgingSecondary ? '0.2em' : '0.1em'};
-  padding-top: 0.7em;
-  padding-bottom: 0.7em;
-  padding-right: ${(props): string => props.isJudgingSecondary ? '3em' : '0.7em'};
-  padding-left: ${(props): string => props.isJudgingSecondary ? '3em' : '0.7em'};
+  border-color: ${colors.BUTTON_DARK_GREEN};
+  letter-spacing: 0.1em;
+  padding-top: 1em;
+  padding-bottom: 1em;
+  width: 10.5em;
   border-radius: 2em;
-  border: 0.1em solid; 
-  cursor: pointer;
+  border: 2em;
+  cursor: ${(props): string => (props.isClickable ? 'pointer' : 'cursor')};
   font-size: 1em;
+  @media ${max.tabletLg} {
+    width: 9.4em;
+  }
   @media ${max.tablet} {
-    font-size: 0.8em;
-  } ;
+    font-size: 1.1em;
+    width: 13em;
+  }
 `;
 
 export { StyledSecondaryButton };

--- a/shared-ui/components/secondary-button/SecondaryButton.tsx
+++ b/shared-ui/components/secondary-button/SecondaryButton.tsx
@@ -2,10 +2,14 @@ import React from 'react';
 import { StyledSecondaryButton } from './SecondaryButton.styles';
 import { ButtonProps } from '../../lib/types';
 
-const SecondaryButton: React.FC<ButtonProps> = ({ btnText, btnLink, isJudgingSecondary = false, }) => {
+const SecondaryButton: React.FC<ButtonProps> = ({
+  btnText,
+  btnLink,
+  isClickable = true
+}) => {
   return (
     <a href={btnLink}>
-      <StyledSecondaryButton isJudgingSecondary={isJudgingSecondary}>
+      <StyledSecondaryButton isClickable={isClickable}>
         {btnText}
       </StyledSecondaryButton>
     </a>

--- a/shared-ui/lib/types.ts
+++ b/shared-ui/lib/types.ts
@@ -4,17 +4,13 @@ export interface StyledPrimaryButtonProps {
   isSmall: boolean | undefined;
 }
 
-export interface StyledSecondaryButtonProps {
-  isJudgingSecondary: boolean | undefined;
-}
-
 export interface ButtonProps {
   btnText: string;
   btnLink?: string;
   newTab?: boolean;
   onClick?: MouseEventHandler;
   isSmallPrimary?: boolean;
-  isJudgingSecondary?: boolean;
+  isClickable?: boolean;
 }
 
 export interface DropdownProps {
@@ -100,7 +96,6 @@ export interface BackgroundProps {
 export interface MobileTeamColumnProps {
   listOfColumnInfo: TeamColumnInfo[];
 }
-
-export interface StyledTeamLabelProps {
-  twoLines: boolean;
+export interface StyledSecondaryButtonProps {
+  isClickable: boolean;
 }


### PR DESCRIPTION
Updates meet the team to use buttons instead of labels (Sarah requested this change a while back) 

Fixes #115.

Changelist:

- Update the secondary button to look like this 
<img width="306" alt="Screenshot 2023-01-11 at 6 30 12 PM" src="https://user-images.githubusercontent.com/59738880/211940230-5482c19e-2947-44a5-9d6e-d22af586cf04.png">
- Updated the meet the team headers to be buttons instead of labels 
<img width="178" alt="Screenshot 2023-01-11 at 6 41 27 PM" src="https://user-images.githubusercontent.com/59738880/211941553-4a107ada-c7b3-4de2-8e94-a672d67377a7.png">
- Spaced out the columns a bit more on larger desktops to more closely follow Figma

Tested:

- Tested on different screensizes

NOTES (since Figma is a bit out of date - I confirmed all of this with Sarah tho): 
- On mobile, the arrows are next to the button header 
- There should be NO green border
<img width="507" alt="Screenshot 2023-01-11 at 6 42 25 PM" src="https://user-images.githubusercontent.com/59738880/211941659-9aa1c6b9-b803-4f4f-b66a-bca2e755111a.png">

Screenshots & Screencasts:

https://user-images.githubusercontent.com/59738880/211941736-442d9e46-d415-4216-bf46-6ddbf4e401f4.mov

