### PR TITLE
judging Algo

### DIFF
--- a/judging-algorithm/formSchedule.ts
+++ b/judging-algorithm/formSchedule.ts
@@ -1,0 +1,116 @@
+import {
+  FinalOutputTables,
+  HackerOutput,
+  HackerTeam,
+  JudgeOutput
+} from './types';
+
+// driver code, takes parsed values and creates random assignments
+// the judges and hacker teams it take in have already been filtered, and rooms have been filtered for capacity
+export function sortJudgesAndPeople(
+  allTimes: string[],
+  allJudgingRooms: string[],
+  unassignedTeams: HackerTeam[],
+  unassignedJudges: string[]
+): FinalOutputTables {
+  const judgesTable: JudgeOutput[] = [];
+  const hackerTable: HackerOutput[] = [];
+  const roomsToJudgeOutputs = new Map<string, JudgeOutput[]>();
+  const finalOutput: FinalOutputTables = {
+    judgeOutput: judgesTable,
+    hackerOutput: hackerTable
+  };
+  // judges assignment
+  const judgesPerRoom = Math.ceil(
+    unassignedJudges.length / allJudgingRooms.length
+  );
+  for (const room of allJudgingRooms) {
+    for (let judgeCount = 0; judgeCount < judgesPerRoom; judgeCount++) {
+      if (unassignedJudges.length > 0) {
+        const judgeToAssignIdx = Math.floor(
+          Math.random() * unassignedJudges.length + 1
+        );
+        const newJudge: JudgeOutput = assignJudgeToRoom(
+          unassignedJudges[judgeToAssignIdx],
+          room
+        );
+        unassignedJudges.splice(judgeToAssignIdx, 1);
+        judgesTable.push(newJudge); // we mutate this later
+        // add to the mapping of room number to judges
+        if (roomsToJudgeOutputs.has(room)) {
+          roomsToJudgeOutputs.get(room).push(newJudge);
+        } else {
+          roomsToJudgeOutputs.set(room, [newJudge]);
+        }
+      }
+    }
+  }
+
+  // people assignment
+  let curTimeSlotIdx = 0;
+  while (unassignedTeams.length > 0) {
+    const timeSlot = allTimes[curTimeSlotIdx];
+    for (
+      const room of allJudgingRooms
+    ) {
+      if (unassignedTeams.length == 0) {
+        break;
+      }
+      const teamToAssignIndx = Math.floor(
+        Math.random() * unassignedJudges.length + 1
+      );
+      const teamToAssign = unassignedTeams[teamToAssignIndx] // select a random team from the unassigned teams
+      unassignedTeams.splice(teamToAssignIndx, 1);
+      const hackerOutput: HackerOutput = assignTeamToTime(
+        timeSlot,
+        teamToAssign,
+        room,
+        roomsToJudgeOutputs
+      );
+      hackerTable.push(hackerOutput);
+    }
+    curTimeSlotIdx++;
+  }
+
+  return finalOutput;
+}
+
+// returns one hackertable entry
+// mutates every single JudgeOutput the map maps to
+// return HackerOutput object, mutates the judge passed in
+function assignTeamToTime(
+  timeSlot: string,
+  hackerTeam: HackerTeam,
+  room: string,
+  roomToJudgeOutput: Map<string, JudgeOutput[]>
+): HackerOutput {
+  const judgeGroup: JudgeOutput[] = roomToJudgeOutput.get(room);
+  for (const judge of judgeGroup) {
+    judge.project = hackerTeam.name;
+    judge.devPostLink = hackerTeam.devpostLink;
+  }
+  const judgeNames: string[] = judgeGroup.map(
+    (judgeOutput) => judgeOutput.judge
+  );
+  const hackerOutput: HackerOutput = {
+    project: hackerTeam.name,
+    time: timeSlot,
+    judges: judgeNames,
+    room: room
+  };
+  return hackerOutput;
+}
+
+// judges will always be in the same room for all timeslots
+// no mutations, returns the new judge
+function assignJudgeToRoom(judge: string, room: string): JudgeOutput {
+  const newJudge: JudgeOutput = {
+    room: room,
+    judge: judge,
+    project: '',
+    devPostLink: '',
+    inPersonDemo: false,
+    time: ''
+  };
+  return newJudge;
+}

--- a/judging-algorithm/index.ts
+++ b/judging-algorithm/index.ts
@@ -1,0 +1,31 @@
+import { FinalOutputTables, HackerTeam, Judge, Room } from "./types";
+import { sortJudgesAndPeople } from "./formSchedule";
+import { parseHackerTeamCSV, parseJudgeCSV, parseRoomsCSV } from "./parser";
+
+// hardcode based on hackathon needs
+const allTimes: string[] = ['10:00', '10:15', '10:30', '10:45', '11:00', '11:15', '11:30', '11:45'];
+
+function main(): FinalOutputTables {
+  // read the CSV and capacity arguments from CLI
+  const filePaths: string[] = process.argv.slice(2) 
+  const judgeCsvFilePath: string = filePaths[0];
+  const roomsCsvFilePath: string = filePaths[1];
+  const teamsCsvFilePath: string = filePaths[2];
+  const minCapacityRequired: number = parseInt(filePaths[3]);
+  
+  // parse the hacker CSV in to TS objects
+  const allJudges: Judge[] = parseJudgeCSV(judgeCsvFilePath);
+  const allRooms: Room[] = parseRoomsCSV(roomsCsvFilePath);
+  const allHackers: HackerTeam[] = parseHackerTeamCSV(teamsCsvFilePath);
+
+  // apply constraints to parsed data
+  const allAwardEligibleHackers = allHackers.filter(team => team.liveDemo);  
+  const capacityAvailableRooms = allRooms.filter(room => room.capacity >= minCapacityRequired);
+
+  // extract string names for: judges, hackers and teams
+  const judgeStrings = allJudges.map(judge => judge.name);
+  const roomStrings = capacityAvailableRooms.map(room => room.name);
+
+  // handles randomized placement and outputs a judge table and a hacker table for front-end
+  return sortJudgesAndPeople(allTimes, roomStrings, allAwardEligibleHackers, judgeStrings);
+}

--- a/judging-algorithm/package.json
+++ b/judging-algorithm/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "judging-algorithm",
+    "version": "1.0.0",
+    "description": "Judging schedule for HackBeanpot",
+    "main": "index.ts",
+    "scripts": {
+      "test": "echo \"Error: no test specified\" && exit 1"
+    },
+    "author": "david yan, lisa jiang, jessica su, surbhi gulati",
+    "license": "ISC",
+    "dependencies": {
+      "csv-parse": "^5.3.3"
+    }
+  }

--- a/judging-algorithm/parser.ts
+++ b/judging-algorithm/parser.ts
@@ -1,0 +1,28 @@
+import * as fs from "fs";
+import * as path from "path";
+import { parse } from 'csv-parse/sync';
+import { HackerTeam, Judge, Room } from "./types";
+
+function parseCsv<T> (csvFilePath: string, headers: string[] | boolean): T[] {
+  const csvFileAbsolutePath = path.resolve(__dirname, csvFilePath);
+
+  const fileContent = fs.readFileSync(csvFileAbsolutePath, { encoding: 'utf-8' });
+
+  const options = {
+    delimiter: ',',
+    columns: headers,
+  };
+  return parse(fileContent, options);
+};
+
+export function parseJudgeCSV(judgeCsvFilePath: string): Judge[] {
+  return parseCsv<Judge>(judgeCsvFilePath, true);
+};
+
+export function parseHackerTeamCSV(hackerTeamCsvFilePath: string): HackerTeam[] {
+  return parseCsv<HackerTeam>(hackerTeamCsvFilePath, true);
+};
+
+export function parseRoomsCSV(roomCsvFilePath: string): Room[] {
+  return parseCsv<Room>(roomCsvFilePath, true);
+};

--- a/judging-algorithm/types.ts
+++ b/judging-algorithm/types.ts
@@ -1,0 +1,42 @@
+export type Judge = {
+  name: string,
+  inPerson: boolean,
+  company: string
+}
+// const judgeHeaders: Array<keyof Judge> = ['name', 'inPerson', 'company'];
+
+export type HackerTeam = {
+  name: string;
+  liveDemo: boolean;
+  devpostLink: string;
+}
+export const hackerTeamHeaders: Array<string> = ['Project Title', 'Will You Be Able To Give A Live Demo Of Your Project To Judges?'];
+
+export type Room = {
+  name: string,
+  capacity: number;
+}
+
+export type JudgeOutput = {
+  judge: string, 
+  time: string,
+  project: string, 
+  devPostLink: string, 
+  inPersonDemo: boolean, 
+  room: string
+}
+
+export type FinalOutputTables = {
+  judgeOutput: JudgeOutput;
+  hackerOutput: HackerOutput;
+}
+
+export type HackerOutput = {
+  project: string, 
+  time: string, 
+  judges: string[], 
+  room: string
+}
+
+
+// const roomHeaders: Array<keyof Judge> = ['name', 'inPerson', 'company'];


### PR DESCRIPTION
Creates a new TS app in the monorepo to sort our judges and hackers.

Fixes #93 

Changelist:

Create a new TS app + tsconfig for eslint for our /judging-algorithm repo
Parse judge, team and hacker information from 3 separate CSV inputs using TS parser
Transform parsed data by randomly selecting rooms for judges & rooms and timeslots for hackers to be situated in
Create judgeOutput and hackerOutput arrays with all needed columns for front-end tables
Design decisions were driven by:

discussion with project logistics team and
decisions we made on this doc while planning out the algorithm: https://docs.google.com/document/d/15KmkRKaDhdJ6eoIUn6c6Nhi4_AnHLRW0Mh4DzkMDAbs/edit. Some revisions are made from Judy's original ticket
Tested: with CSV examples that are also pushed up