### PR TITLE
Airtable setup

### DIFF
--- a/live-site/components/coming-up/ComingUp.tsx
+++ b/live-site/components/coming-up/ComingUp.tsx
@@ -14,20 +14,27 @@ import {
 } from './ComingUp.styles';
 import { min } from '../../../shared-ui/lib/responsive';
 import useMatchMedia from 'react-use-match-media';
+import { useAirtableApi } from '../../src/hooks/useAirtable';
 
 const ComingUpSection: React.FC = () => {
-  const event: UpcomingEvent = {
-    id: 0,
-    header: 'Register your team',
-    time: 'Complete by 12:00am EST',
-    body: 'hello hello hello hello hello hello hello hello hi hi hello hello hello hi hi'
-  };
-  const events: UpcomingEvent[] = [event, event, event];
+  const { data } = useAirtableApi('Schedule', 'schedule');
+  const events: UpcomingEvent[]= Array.from(
+    new Set(
+    data.map((event) => {
+      return {
+        id: event.fields.id,
+        header: event.fields.title,
+        time: event.fields.time,
+        body: event.fields.notes,
+      }
+    }))
+  )
   const isDesktop = useMatchMedia(min.tablet);
   if (events.length === 0) {
     return <NoUpcoming />;
   }
   if (events.length === 1 && !isDesktop) {
+    const event: UpcomingEvent = events[0];
     return (
       <StyledSectionContainer>
         <StyledSectionHeader>Coming up...</StyledSectionHeader>

--- a/live-site/components/coming-up/ComingUp.tsx
+++ b/live-site/components/coming-up/ComingUp.tsx
@@ -17,7 +17,7 @@ import useMatchMedia from 'react-use-match-media';
 import { useAirtableApi } from '../../src/hooks/useAirtable';
 
 const ComingUpSection: React.FC = () => {
-  const { data } = useAirtableApi('Relevant', 'relevant');
+  const { data } = useAirtableApi('Relevant', 'relevant', true);
   let count = 0; 
   let events: UpcomingEvent[]= Array.from(
     new Set(

--- a/live-site/components/coming-up/ComingUp.tsx
+++ b/live-site/components/coming-up/ComingUp.tsx
@@ -26,11 +26,13 @@ const ComingUpSection: React.FC = () => {
         return {
           id: count,
           header: event.fields.title,
-          time: event.fields.time,
+          time: event.fields.start_time,
+          display_start_time: event.fields.display_start_time,
           body: event.fields.notes,
         } 
     }))
   )
+  events.sort((event1: UpcomingEvent, event2: UpcomingEvent) => (event1.time > event2.time) ? 1 : -1);
   events = events.slice(0, 3); 
   const isDesktop = useMatchMedia(min.tablet);
   if (events.length === 0) {
@@ -45,7 +47,7 @@ const ComingUpSection: React.FC = () => {
           <StyledEvent key={event.id}>
             <StyledTextContainer>
               <StyledHeader>{event.header}</StyledHeader>
-              <StyledTime>{event.time}</StyledTime>
+              <StyledTime>{event.display_start_time}</StyledTime>
               <StyledBody>{event.body}</StyledBody>
             </StyledTextContainer>
           </StyledEvent>
@@ -61,7 +63,7 @@ const ComingUpSection: React.FC = () => {
           <StyledEvent key={event.id}>
             <StyledTextContainer>
               <StyledHeader>{event.header}</StyledHeader>
-              <StyledTime>{event.time}</StyledTime>
+              <StyledTime>{event.display_start_time}</StyledTime>
               <StyledBody>{event.body}</StyledBody>
             </StyledTextContainer>
           </StyledEvent>

--- a/live-site/components/coming-up/ComingUp.tsx
+++ b/live-site/components/coming-up/ComingUp.tsx
@@ -18,13 +18,15 @@ import { useAirtableApi } from '../../src/hooks/useAirtable';
 
 const ComingUpSection: React.FC = () => {
   const { data } = useAirtableApi('Relevant', 'relevant');
+  let count = 0; 
   const events: UpcomingEvent[]= Array.from(
     new Set(
     data.map((event) => {
+      count = count + 1;
       return {
-        id: 0,
+        id: count,
         header: event.fields.title,
-        time: event.fields.time,
+        time: event.fields.time + count,
         body: event.fields.notes,
       }
     }))

--- a/live-site/components/coming-up/ComingUp.tsx
+++ b/live-site/components/coming-up/ComingUp.tsx
@@ -19,18 +19,19 @@ import { useAirtableApi } from '../../src/hooks/useAirtable';
 const ComingUpSection: React.FC = () => {
   const { data } = useAirtableApi('Relevant', 'relevant');
   let count = 0; 
-  const events: UpcomingEvent[]= Array.from(
+  let events: UpcomingEvent[]= Array.from(
     new Set(
     data.map((event) => {
       count = count + 1;
-      return {
-        id: count,
-        header: event.fields.title,
-        time: event.fields.time + count,
-        body: event.fields.notes,
-      }
+        return {
+          id: count,
+          header: event.fields.title,
+          time: event.fields.time,
+          body: event.fields.notes,
+        } 
     }))
   )
+  events = events.slice(0, 3); 
   const isDesktop = useMatchMedia(min.tablet);
   if (events.length === 0) {
     return <NoUpcoming />;

--- a/live-site/components/coming-up/ComingUp.tsx
+++ b/live-site/components/coming-up/ComingUp.tsx
@@ -17,12 +17,12 @@ import useMatchMedia from 'react-use-match-media';
 import { useAirtableApi } from '../../src/hooks/useAirtable';
 
 const ComingUpSection: React.FC = () => {
-  const { data } = useAirtableApi('Schedule', 'schedule');
+  const { data } = useAirtableApi('Relevant', 'relevant');
   const events: UpcomingEvent[]= Array.from(
     new Set(
     data.map((event) => {
       return {
-        id: event.fields.id,
+        id: 0,
         header: event.fields.title,
         time: event.fields.time,
         body: event.fields.notes,

--- a/live-site/lib/types.ts
+++ b/live-site/lib/types.ts
@@ -13,6 +13,7 @@ export interface UpcomingEvent {
   id: number;
   header: string;
   time: string;
+  display_start_time: string; 
   body: string;
 }
 

--- a/live-site/src/hooks/useAirtable.ts
+++ b/live-site/src/hooks/useAirtable.ts
@@ -64,6 +64,5 @@ export const useAirtableApiWithPagination = (
       setIsLoading(false);
     }
   }, [baseName, tableName]);
-
   return { data, isLoading };
 };


### PR DESCRIPTION
Fixes Issue: #123 

You can play around with the air table here!
https://airtable.com/appGneFS4n9rOllSC/tblBIfb8cdcZgZMwU/viw8KvmLyjwms9dN9?blocks=hide

Figma: https://www.figma.com/file/xLGm0VA2EKkryPoqOYxl5p/2023-Live-Site-Designs?node-id=1%3A2&t=d9IcEO1AXvOyXJtF-0

- Upcoming events should properly display the first 3 upcoming events
- added another field to the UpcomingEvent object to differentiate between display times and actual times. 

<img width="1501" alt="Screen Shot 2023-01-19 at 11 10 52 PM" src="https://user-images.githubusercontent.com/37753574/213615652-bddd8921-9ff6-4c3c-859b-8c59f8ba5717.png">
<img width="1433" alt="Screen Shot 2023-01-19 at 11 15 46 PM" src="https://user-images.githubusercontent.com/37753574/213616144-a1bc421c-7d59-4742-81b7-68ce446acb8a.png">
<img width="1445" alt="Screen Shot 2023-01-19 at 11 16 12 PM" src="https://user-images.githubusercontent.com/37753574/213616175-bfd05b94-d033-4e12-8087-9c609408be91.png">
