### PR TITLE
Check isDev in airtable hook

### DIFF
--- a/live-site/components/coming-up/ComingUp.tsx
+++ b/live-site/components/coming-up/ComingUp.tsx
@@ -24,6 +24,7 @@ const ComingUpSection: React.FC = () => {
   };
   const events: UpcomingEvent[] = [event, event, event];
   const isDesktop = useMatchMedia(min.tablet);
+
   if (events.length === 0) {
     return <NoUpcoming />;
   }

--- a/live-site/src/hooks/useAirtable.ts
+++ b/live-site/src/hooks/useAirtable.ts
@@ -16,10 +16,9 @@ export const useAirtableApi = (
   const [data, setData] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
   useEffect(() => {
-    let url = `${BASEURL}/${baseName}/${tableName}`;
-    if (isDev) {
-      url = url + '?isDev=true';
-    }
+    const url = `${BASEURL}/${baseName}/${tableName}${
+      isDev ? '?isDev=true' : ''
+    }`;
     try {
       fetch(url)
         .then((data) => {

--- a/live-site/src/hooks/useAirtable.ts
+++ b/live-site/src/hooks/useAirtable.ts
@@ -10,12 +10,16 @@ interface AirtableData {
 
 export const useAirtableApi = (
   baseName: string,
-  tableName: string
+  tableName: string,
+  isDev = false
 ): AirtableData => {
   const [data, setData] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
   useEffect(() => {
-    const url = `${BASEURL}/${baseName}/${tableName}`;
+    let url = `${BASEURL}/${baseName}/${tableName}`;
+    if (isDev) {
+      url = url + '?isDev=true';
+    }
     try {
       fetch(url)
         .then((data) => {


### PR DESCRIPTION
Check isDev in airtable hook

NOTE: this PR is to be reviewed with this one in the airtable cache proxy https://github.com/HackBeanpot/airtable-cache-proxy/pull/2

Changelist:
- If we are passed the dev parameter, we want to directly hit the airtable api without caching so we add this as a query param. 
- Otherwise, we will cache

Tested:

- I tested this by running yarn dev in the airtable cache proxy repo and changing the base url to be the local port. So it should work with the actual base url when everything is merged in.
