### PR TITLE
header-fix

### DIFF
--- a/shared-ui/components/header/Header.styles.ts
+++ b/shared-ui/components/header/Header.styles.ts
@@ -6,7 +6,7 @@ import { P, fonts } from '../../style/typography';
 
 const StyledHeader = styled.div<StyledHeaderProps>`
    {
-    height: ${(props): string => (props.isOpen ? '40em' : '4.8em')};
+    height: ${(props): string => (props.isOpen ? '45em' : '4.8em')};
     background-color: ${(props): string =>
       props.isDay ? colors.HEADER_FOOTER_BLUE : colors.NIGHT_HEADER_COLOR};
     width: 100%;


### PR DESCRIPTION
<Summary line - One sentence describing your intended set of changes>

Fixes #138 

Changelist:

- Made the mobile nav bar height taller when open

Tested:
- localhost

Screenshots & Screencasts:

### Before

<img width="414" alt="Screen Shot 2023-01-25 at 5 21 46 PM" src="https://user-images.githubusercontent.com/103906123/214705120-2b9fd5fa-65e0-4b2d-8ddc-b8ae9fcb36c0.png">


### After

<img width="694" alt="Screen Shot 2023-01-25 at 5 14 08 PM" src="https://user-images.githubusercontent.com/103906123/214704752-2eb4eec1-5dde-4781-8099-e1cf56c7948b.png">


