### PR TITLE
Raffle: airtable updates + point logic

### DIFF
--- a/live-site/components/welcome-section/WelcomeSection.tsx
+++ b/live-site/components/welcome-section/WelcomeSection.tsx
@@ -8,7 +8,11 @@ import {
   StyledWelcomeSectionContent,
   StyledWelcomeText
 } from './WelcomeSection.styles';
-import { TeamInfo as defaultTeamInfo } from '../../lib/data';
+import {
+  TeamInfo as defaultTeamInfo,
+  onePointCodes,
+  twoPointCodes
+} from '../../lib/data';
 import { RaffleEntry, TeamProps } from '../../lib/types';
 import { useAirtableApi } from '../../src/hooks/useAirtable';
 
@@ -23,7 +27,8 @@ const WelcomeSection: React.FC = () => {
       data.map((entry) => {
         return {
           name: entry.fields.Name ?? '',
-          cabin: entry.fields.Cabin ?? ''
+          cabin: entry.fields.Cabin ?? '',
+          eventCode: entry.fields['Event Code'] ?? ''
         };
       })
     );
@@ -33,10 +38,22 @@ const WelcomeSection: React.FC = () => {
     const newTeamInfo = defaultTeamInfo.map((team) => {
       return { ...team };
     });
+
+    // make sure we don't double count a entry with the same name and event code
+    const seenEntries = new Set<string>();
+
     raffleEntries.forEach((entry) => {
       newTeamInfo.forEach((team) => {
-        if (team.name === entry.cabin) {
-          team.points += 1;
+        if (
+          team.name === entry.cabin &&
+          !seenEntries.has(entry.name + entry.eventCode)
+        ) {
+          if (onePointCodes.includes(entry.eventCode)) {
+            team.points += 1;
+          } else if (twoPointCodes.includes(entry.eventCode)) {
+            team.points += 2;
+          }
+          seenEntries.add(entry.name + entry.eventCode);
         }
       });
       setTeamInfo(newTeamInfo);

--- a/live-site/components/welcome-section/team-race/Team.tsx
+++ b/live-site/components/welcome-section/team-race/Team.tsx
@@ -18,7 +18,7 @@ const Team: React.FC<TeamProps> = ({ name, points, position, index }) => {
         <StyledTeamName> {name}</StyledTeamName>
       </StyledTeamTextContainer>
       <StyledCarContainer>
-        <TeamCar points={points} index={index} eventItem={undefined} />
+        <TeamCar points={points} index={index} />
         <StyledTeamPoint>{points} PTS</StyledTeamPoint>
       </StyledCarContainer>
     </StyledTeamContainer>

--- a/live-site/components/welcome-section/team-race/TeamRace.tsx
+++ b/live-site/components/welcome-section/team-race/TeamRace.tsx
@@ -10,8 +10,8 @@ import { StyledTeamHeader } from './Team.styles';
 
 const TeamRace: React.FC<TeamRaceProps> = ({ teams }) => {
   const orderTeams = (teams: TeamProps[]): TeamProps[] => {
-    return teams.sort((team1: TeamProps, team2: TeamProps) =>
-      team1.points > team2.points ? -1 : -1
+    return teams.sort(
+      (team1: TeamProps, team2: TeamProps) => team2.points - team1.points
     );
   };
 
@@ -24,6 +24,7 @@ const TeamRace: React.FC<TeamRaceProps> = ({ teams }) => {
         </StyledRaceContent>
         {orderTeams(teams).map((team: TeamProps, position: number) => (
           <Team
+            key={team.index}
             name={team.name}
             points={team.points}
             position={position + 1}

--- a/live-site/lib/data.ts
+++ b/live-site/lib/data.ts
@@ -10,11 +10,11 @@ const liveSiteTabInfo: TabInfo[] = [
 ];
 
 const TeamInfo: TeamProps[] = [
-  { name: 'TEAM TATOOINE', points: 100, index: 0 },
-  { name: 'TEAM ESSOS', points: 82, index: 1 },
-  { name: 'TEAM SI WONG', points: 66, index: 2 },
-  { name: 'TEAM ARRAKIS', points: 33, index: 3 },
-  { name: 'TEAM DESSERT BIOME', points: 0, index: 4 }
+  { name: 'Team Tatooine', points: 0, index: 0 },
+  { name: 'Team Essos', points: 0, index: 1 },
+  { name: 'Team SI Wong', points: 0, index: 2 },
+  { name: 'Team Arrakis', points: 0, index: 3 },
+  { name: 'Team Desert Biome', points: 0, index: 4 }
 ];
 
 interface TimeLeft {

--- a/live-site/lib/data.ts
+++ b/live-site/lib/data.ts
@@ -17,6 +17,11 @@ const TeamInfo: TeamProps[] = [
   { name: 'Team Desert Biome', points: 0, index: 4 }
 ];
 
+// TODO: replace with actual event codes
+const onePointCodes = ['WORKSHOP', 'SOCIAL'];
+
+const twoPointCodes = ['EXCURSION', 'ACTIVITY'];
+
 interface TimeLeft {
   timeType: string;
   value: number;
@@ -68,4 +73,11 @@ const eventItemInfo: EventItem[] = [
   }
 ];
 
-export { liveSiteTabInfo, TimeLeft, eventItemInfo, TeamInfo };
+export {
+  liveSiteTabInfo,
+  TimeLeft,
+  eventItemInfo,
+  TeamInfo,
+  onePointCodes,
+  twoPointCodes
+};

--- a/live-site/lib/types.ts
+++ b/live-site/lib/types.ts
@@ -71,6 +71,11 @@ export interface EventItemProps {
   eventItem: EventItem;
 }
 
+export interface RaffleEntry {
+  name: string;
+  cabin: string;
+}
+
 export interface TeamProps {
   points: number;
   name: string;
@@ -85,7 +90,6 @@ export interface TeamRaceProps {
 export interface TeamCarProps {
   points: number;
   index: number;
-  eventItem: EventItem;
 }
 
 export interface MentorInfo {

--- a/live-site/lib/types.ts
+++ b/live-site/lib/types.ts
@@ -74,6 +74,7 @@ export interface EventItemProps {
 export interface RaffleEntry {
   name: string;
   cabin: string;
+  eventCode: string;
 }
 
 export interface TeamProps {


### PR DESCRIPTION
updates airtable form with team names and prize bucket names, and adds point calculation to live site

Fixes #125 

Changelist:

- Gets team point values from airtable
- Points are counted according to [this doc](https://docs.google.com/document/d/19x_MmnKEec5CXrVLLCG6OmUlZ11gD0oT2jQ0hMUwVF4/edit?usp=sharing). There will be two-point event codes and one-point event codes, however the codes aren't finalized yet so I've used placeholder codes defined in `/live-site/lib/data.ts`.
- Duplicate raffle entries aren't counted, and entries without an event code aren't counted (should i make the event code a required question in airtable?)

Notes:

- I'm not the best at writing English 💀 so looking at the airtable form [here](https://airtable.com/app9pkEjk7iSp7mR4/tblPObGGc7FjSMoHI/viwpMQki3ua0UMOOj?blocks=hide) would be much appreciated

Tested:

- locally chrome + firefox on windows 10
