### PR TITLE
Cactus Responsiveness / Feedback Typo

### DIFF
--- a/live-site/components/feedback-join-core-section/FeedbackJoinCoreSection.tsx
+++ b/live-site/components/feedback-join-core-section/FeedbackJoinCoreSection.tsx
@@ -13,7 +13,7 @@ const FeedbackJoinCoreSection: React.FC = () => {
       <StyledColumn>
         <StyledColumnTitle>Send us your feedback</StyledColumnTitle>
         <StyledColumnText>
-          We hope you{"'"}re having an awesome time at Camp HackBeanpot! We{"'"}
+          We hope you{"'"}re having an awesome time at HackBeanpot Desert Exploration! We{"'"}
           d really appreciate it if you could share your thoughts in our Event
           Feedback Form below so we can continue to make HackBeanpot a great
           experience for all attendees.

--- a/main-site/components/faq-section/FaqSection.styles.ts
+++ b/main-site/components/faq-section/FaqSection.styles.ts
@@ -15,7 +15,7 @@ const StyledCactus = styled.img`
   top: 0.1em;
   left: 1em;
 
-  @media ${max.tablet} {
+  @media ${max.desktop} {
     width: 13em;
     top: -1em;
     display: none;


### PR DESCRIPTION
<Summary line - One sentence describing your intended set of changes>

Fixes #176

Changelist:

-  Change "Camp HackBeanpot" to "HackBeanpot Desert Exploration" in the FeedbackJoinCore section for the live site
- Changed the breakpoint for the cactus image to desktop from tablet in the main-site in the FAQ section

Notes:

- Design decisions: We decided that instead of making the cactus smaller, we just removed it completely as that is how it was before

Tested:

- We tested the cactus disappearance through the responsive device toolbar at different device sizes

Screenshots & Screencasts:

<img width="1500" alt="image" src="https://github.com/HackBeanpot/mono-repo/assets/76594216/4a7cd163-f6c3-4576-86da-ef8655c9428a">

- Cactus present at desktop size versus other sizes
![image](https://github.com/HackBeanpot/mono-repo/assets/76594216/dd603fef-bfaa-4c55-a650-784fbcc83174)
![image](https://github.com/HackBeanpot/mono-repo/assets/76594216/597200c6-d526-42fb-a4a0-330b74068286)
![image](https://github.com/HackBeanpot/mono-repo/assets/76594216/b813f7f3-5790-4a3e-9214-bf4b3bd84383)


