### PR TITLE
Added Sponsor Packet link to Nav Bar

### DIFF
--- a/shared-ui/components/footer/Footer.tsx
+++ b/shared-ui/components/footer/Footer.tsx
@@ -39,7 +39,11 @@ const Footer: React.FC<FooterProps> = ({ tabs, isDay }) => {
       <StyledFooterContentContainer>
         <StyledTabContainer>
           {tabs.map((tab: TabInfo) => (
-            <StyledLink href={tab.link} key={tab.name}>
+            <StyledLink
+              href={tab.link}
+              key={tab.name}
+              target={tab.newTab ? '_blank' : '_self'}
+            >
               <StyledTab>{tab.name}</StyledTab>
             </StyledLink>
           ))}

--- a/shared-ui/components/header/Header.tsx
+++ b/shared-ui/components/header/Header.tsx
@@ -51,6 +51,7 @@ const Header: React.FC<HeaderProps> = ({ tabs, isDay }) => {
               onClick={(): void => setIsOpen(false)}
               href={tab.link}
               key={tab.name}
+              target= {tab.newTab ? "_blank" : "_self"}
             >
               <StyledTab>{tab.name}</StyledTab>
             </StyledLink>

--- a/shared-ui/lib/data.ts
+++ b/shared-ui/lib/data.ts
@@ -39,6 +39,7 @@ const mainSiteTabInfo: TabInfo[] = [
   { name: 'About', link: '/#about' },
   { name: 'Calendar', link: '/#calendar' },
   { name: 'FAQ', link: '/#faq' },
+  { name: 'Sponsor Us', link: 'https://drive.google.com/file/d/1ttohaF5r457ymHIPI9Tx2jXkt9HLz8gn/view?usp=sharing', newTab: true },
   { name: 'Team', link: '/#team' }
 ];
 

--- a/shared-ui/lib/types.ts
+++ b/shared-ui/lib/types.ts
@@ -24,6 +24,7 @@ export interface DropdownProps {
 export interface TabInfo {
   name: string;
   link: string;
+  newTab?: boolean;
 }
 
 export interface TeamColumnInfo {


### PR DESCRIPTION
Added Sponsor Packet link to Nav Bar

Changelist:

- Added a new tab object to `mainSiteTableInfo` for "Sponsor Us" set to open in a new tab
- Add `newTab` optional prop to `TabInfo` type
- Added target prop to StyledLink in for both header and footer components



Tested:

- localhost

Screenshots & Screencasts:

### Header
<img width="638" alt="Screenshot 2023-07-19 at 7 56 45 PM" src="https://github.com/HackBeanpot/mono-repo/assets/103906123/0047ce5a-28a4-4c83-9861-2041b76709c4">

### Footer
<img width="1210" alt="Screenshot 2023-07-19 at 7 57 00 PM" src="https://github.com/HackBeanpot/mono-repo/assets/103906123/dbb27a2d-56e1-41cf-b50c-89d822c76685">

### Packet Link
<img width="1800" alt="Screenshot 2023-07-19 at 7 57 51 PM" src="https://github.com/HackBeanpot/mono-repo/assets/103906123/11d010b8-99d6-49a5-bd21-35f9872ad67f">
