### PR TITLE
Mandy refresh primary button style

### DIFF
--- a/shared-ui/components/primary-button/PrimaryButton.styles.ts
+++ b/shared-ui/components/primary-button/PrimaryButton.styles.ts
@@ -6,15 +6,17 @@ import { motion } from 'framer-motion';
 import { StyledPrimaryButtonProps } from '../../lib/types';
 
 const StyledPrimaryButton = styled(motion.button)<StyledPrimaryButtonProps>`
-  color: ${colors.HEADER_FOOTER_BLUE};
-  background-color: ${colors.BUTTON_GREEN};
-  border-color: ${colors.HEADER_FOOTER_BLUE};
+  color: ${(props): string => 
+    props.$transparent ? colors.BUTTON_YELLOW : colors.TEXT_DARKBLUE};
+  background-color: ${(props): string => 
+    props.$transparent ? colors.TRANSPARENT : colors.BUTTON_YELLOW};
+  border-color: ${colors.BUTTON_YELLOW} !important;
   font-family: ${fonts.nunitoSansSemibold};
   transition-duration: 0.5s;
   &:hover {
-    color: ${colors.BUTTON_GREEN};
-    background-color: ${colors.HEADER_FOOTER_BLUE};
-    border-color: ${colors.BUTTON_GREEN};
+    color: ${colors.TEXT_DARKBLUE};
+    background-color: ${colors.BUTTON_DARK_YELLOW};
+    border-color: ${colors.BUTTON_DARK_YELLOW} !important;
   }
   padding-right: ${(props): string =>
     props.$isSmallPrimary ? '1.5em' : '1em'};

--- a/shared-ui/components/primary-button/PrimaryButton.tsx
+++ b/shared-ui/components/primary-button/PrimaryButton.tsx
@@ -7,7 +7,8 @@ const PrimaryButton: React.FC<ButtonProps> = ({
   btnText,
   btnLink,
   newTab = false,
-  isSmallPrimary = false
+  isSmallPrimary = false,
+  transparent = false
 }) => {
   const [isClicked, setIsClicked] = useState(false);
   if (!btnLink) {
@@ -27,7 +28,7 @@ const PrimaryButton: React.FC<ButtonProps> = ({
     };
     return (
       <a onClick={onClick}>
-        <StyledPrimaryButton $isSmallPrimary={isSmallPrimary}>
+        <StyledPrimaryButton $isSmallPrimary={isSmallPrimary} $transparent={transparent}>
           {ctaText}
         </StyledPrimaryButton>
       </a>
@@ -41,6 +42,7 @@ const PrimaryButton: React.FC<ButtonProps> = ({
         whileTap="tap"
         variants={buttonAnimations}
         $isSmallPrimary={isSmallPrimary}
+        $transparent={transparent}
       >
         {btnText}
       </StyledPrimaryButton>

--- a/shared-ui/lib/types.ts
+++ b/shared-ui/lib/types.ts
@@ -2,6 +2,7 @@ import { MouseEventHandler } from 'react';
 
 export interface StyledPrimaryButtonProps {
   $isSmallPrimary: boolean | undefined;
+  $transparent: boolean | undefined;
 }
 
 export interface ButtonProps {
@@ -11,6 +12,7 @@ export interface ButtonProps {
   onClick?: MouseEventHandler;
   isSmallPrimary?: boolean;
   isClickable?: boolean;
+  transparent?: boolean;
 }
 
 export interface TimeRemainingProps {

--- a/shared-ui/style/colors.ts
+++ b/shared-ui/style/colors.ts
@@ -43,7 +43,12 @@ const colors = {
   ORANGE: '#FFA500',
   LIGHT_BLUE: '#ADD8E6',
   PURPLE_TAG: '#800080',
-  RACE_LINE: '#ffe799'
+  RACE_LINE: '#ffe799',
+
+  // for primary button
+  BUTTON_YELLOW: '#FABB32',
+  BUTTON_DARK_YELLOW: '#F4A939',
+  TRANSPARENT: 'transparent'
 };
 
 export { colors };


### PR DESCRIPTION
Fixes #245 

**Changelist:**
- Added the `transparent` prop to primary buttons. Default is false.
- Added the new shades of yellow from the figma to our `colors.ts` file as `BUTTON_YELLOW` and `BUTTON_DARK_YELLOW`
- Updated the primary button styling to use the new colors and have a different background, border, and text color if the button is transparent.

<br>

**Screenshots & Screencasts:**
> N.B. Halfway through the video I went in the code and made the transparent prop true so that you could see what it would look like.

[Primary Button Refresh.webm](https://github.com/HackBeanpot/mono-repo/assets/67931161/c483a762-088b-4dee-8467-567f1df90e2c)
