### PR TITLE
Fixed pirate flag being too close to text

### DIFF
--- a/main-site/components/past-projects-section/PastProjectsSection.styles.ts
+++ b/main-site/components/past-projects-section/PastProjectsSection.styles.ts
@@ -218,8 +218,9 @@ const StyledPirateFlag = styled.img`
   }
 
   @media ${max.tabletSm} {
-    top: 8em;
-    width: 9em;
+    top: 7em;
+    left: 3em;
+    width: 7em;
   }
 `;
 


### PR DESCRIPTION
The pirate flag was too close to the text

Screenshots & Screencasts:

previous: 
![image](https://github.com/HackBeanpot/mono-repo/assets/76594216/995ce327-5bbc-4d7a-ab11-54e2b156a5cf)

now:
<img width="306" alt="image" src="https://github.com/HackBeanpot/mono-repo/assets/76594216/0daeec29-7d0b-4b0b-8cf2-20d9c395e685">

