### PR TITLE
carousel hackbeanpot about section mobile fix

### DIFF
--- a/main-site/components/about-section/AboutSection.tsx
+++ b/main-site/components/about-section/AboutSection.tsx
@@ -17,29 +17,18 @@ import {
   StyledItemTitle
 } from './AboutSection.styles';
 import { aboutSectionData } from '../../lib/data';
-import Community from '../../../shared-ui/images/communityShell.png';
-import Exploration from '../../../shared-ui/images/explorationShell.png';
-import Growth from '../../../shared-ui/images/growthShell.png';
 import { AboutSectionData } from '../../lib/types';
 import Arrow from '../../../shared-ui/components/arrow/Arrow';
-import { getLeftOrRight } from '../../lib/utils';
+import { getLeftOrRight, getLeftOrRightCarouselData } from '../../lib/utils';
 import Shell from '../../../shared-ui/images/shell.png';
 
-function getImage(title: string): string {
-  if (title === 'Community') {
-    return Community;
-  }
-  if (title === 'Exploration') {
-    return Exploration;
-  }
-  return Growth;
-}
 
 const AboutSection: React.FC = () => {
   const isDesktop = useMatchMedia(min.tablet);
   const [currItem, setCurrItem] = useState<AboutSectionData>(
     aboutSectionData[0]
   );
+  console.log(currItem);
 
   return (
     <div id="about">
@@ -47,9 +36,9 @@ const AboutSection: React.FC = () => {
         <StyledTitle>HackBeanpot is about...</StyledTitle>
         {!isDesktop && (
           <StyledItemsContainer>
-            <StyledLeftImage src={Community} />
+            <StyledLeftImage src={getLeftOrRightCarouselData("left", aboutSectionData, currItem.id).image} />
             <StyledItemContainer>
-              <StyledCenterImage src={Exploration} />
+              <StyledCenterImage src={currItem.image} />
               <StyledItemTextContainer>
                 <StyledItemTitle color={colors.WHITE}>
                   {currItem.title}
@@ -78,7 +67,7 @@ const AboutSection: React.FC = () => {
                 </StyledArrowDescriptionContainer>
               </StyledItemTextContainer>
             </StyledItemContainer>
-            <StyledRightImage src={Growth} />
+            <StyledRightImage src={getLeftOrRightCarouselData("right", aboutSectionData, currItem.id).image} />
           </StyledItemsContainer>
         )}
 
@@ -86,7 +75,7 @@ const AboutSection: React.FC = () => {
           <StyledItemsContainer>
             {aboutSectionData.map((curr) => (
               <StyledItemContainer key={curr.title}>
-                <StyledItemImage src={getImage(curr.title)} />
+                <StyledItemImage src={curr.image} />
                 <StyledItemTextContainer>
                   <StyledItemTitle color={colors.WHITE}>
                     {curr.title}

--- a/main-site/components/about-section/AboutSection.tsx
+++ b/main-site/components/about-section/AboutSection.tsx
@@ -28,7 +28,6 @@ const AboutSection: React.FC = () => {
   const [currItem, setCurrItem] = useState<AboutSectionData>(
     aboutSectionData[0]
   );
-  console.log(currItem);
 
   return (
     <div id="about">

--- a/main-site/components/testimonials-section/testimonials/Testimonials.tsx
+++ b/main-site/components/testimonials-section/testimonials/Testimonials.tsx
@@ -91,7 +91,7 @@ const Testimonials: React.FC<TestimonialsSectionProps> = ({
             }
           />
         )}
-           {
+        {
           <StyledTestimonialsRightContainer>
             <LeftOrRightTestimonialCard
               isSponsor={isSponsor}

--- a/main-site/components/testimonials-section/testimonials/Testimonials.tsx
+++ b/main-site/components/testimonials-section/testimonials/Testimonials.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import useMatchMedia from 'react-use-match-media';
-import { getLeftOrRight, getLeftOrRightTestimonial } from '../../../lib/utils';
+import { getLeftOrRight, getLeftOrRightCarouselData } from '../../../lib/utils';
 import TestimonialCard from '../testimonial-card/TestimonialCard';
 import {
   StyledTestimonialsCenterContainer,
@@ -23,12 +23,12 @@ const Testimonials: React.FC<TestimonialsSectionProps> = ({
   const isDesktop = useMatchMedia(min.tablet);
   const [currentIndex, setCurrentIndex] = useState<number>(0);
 
-  const getLeftTestimonial: TestimonialData = getLeftOrRightTestimonial(
+  const getLeftTestimonial: TestimonialData = getLeftOrRightCarouselData(
     'left',
     testimonialData,
     currentIndex
   );
-  const getRightTestimonial: TestimonialData = getLeftOrRightTestimonial(
+  const getRightTestimonial: TestimonialData = getLeftOrRightCarouselData(
     'right',
     testimonialData,
     currentIndex

--- a/main-site/lib/data.ts
+++ b/main-site/lib/data.ts
@@ -21,22 +21,32 @@ import intuitLogo from '../images/intuitLogo.png';
 import microsoftLogoPadded from '../images/microsoftLogoPadded.png';
 import woodMackenzieLogo from '../images/woodMackenzieLogo.png';
 import SchoolofFish from '../images/school-fish.svg'
+import Community from '../../shared-ui/images/communityShell.png';
+import Exploration from '../../shared-ui/images/explorationShell.png';
+import Growth from '../../shared-ui/images/growthShell.png';
+
 
 export const aboutSectionData: AboutSectionData[] = [
   {
+    id: 0,
     title: 'Community',
     description:
-      'Connect with fellow students and our partners in the tech community. Make connections that will last a lifetime!'
+      'Connect with fellow students and our partners in the tech community. Make connections that will last a lifetime!',
+    image: Community,
   },
   {
+    id: 1,
     title: 'Exploration',
     description:
-      'Discover new ideas and technologies with the help of our experienced mentors, or learn new skills at our beginner-friendly workshops!'
+      'Discover new ideas and technologies with the help of our experienced mentors, or learn new skills at our beginner-friendly workshops!',
+    image: Exploration
   },
   {
+    id: 2,
     title: 'Growth',
     description:
-      'Expand beyond your horizons and grow your current skill set in a safe and supportive environment.'
+      'Expand beyond your horizons and grow your current skill set in a safe and supportive environment.',
+    image: Growth,
   }
 ];
 
@@ -59,9 +69,9 @@ export const FaqSectionData: FaqData[] = [
     id: 3,
     question: 'How long is the event?',
     answer:
-    'The event will last an entire weekend in February, starting at around 7pm EST the Friday leading into the weekend and continuing until 3:30pm EST on Sunday. Please note that these times are tentative and subject to change as we get closer to the event date - please check our Instagram (@hackbeanpot) for the most updated information! Throughout the weekend, there will be different workshops, activities, and opportunities to network with sponsors. A more detailed schedule will be released about a month out from the event. Sign up for our newsletter to stay updated!'
+      'The event will last an entire weekend in February, starting at around 7pm EST the Friday leading into the weekend and continuing until 3:30pm EST on Sunday. Please note that these times are tentative and subject to change as we get closer to the event date - please check our Instagram (@hackbeanpot) for the most updated information! Throughout the weekend, there will be different workshops, activities, and opportunities to network with sponsors. A more detailed schedule will be released about a month out from the event. Sign up for our newsletter to stay updated!'
   },
-  
+
   {
     id: 4,
     question: 'How do I apply to attend HackBeanpot?',
@@ -288,7 +298,7 @@ export const eventsCalendarData: EventsCalendarData[] = [
   {
     title: 'Intro to React',
     subtitle: 'MiniHacks 2',
-    punchline: 'Learn the FUNdamentals of WebDev', 
+    punchline: 'Learn the FUNdamentals of WebDev',
     description: 'Learn the basics of HTML, CSS, and JS',
     prerequisites: 'None!',
     date: convertToJSDate(2023, 10, 28),
@@ -299,7 +309,7 @@ export const eventsCalendarData: EventsCalendarData[] = [
   {
     title: 'A Builder’s Entrepreneurial Journey',
     subtitle: 'An Intercollegiate Mixer',
-    punchline: 'A collab event with Sandbox, Entrepreneurs Club, and Odds on VC!', 
+    punchline: 'A collab event with Sandbox, Entrepreneurs Club, and Odds on VC!',
     description: "This is a great opportunity to experience the process of pursuing a venture idea from a technical founder's perspective and network with aspiring student founders from Northeastern, BU, Bentley, and more!",
     prerequisites: 'None!',
     date: convertToJSDate(2023, 11, 5),
@@ -323,5 +333,5 @@ export const CountdownData: CountdownProps[] = [
 ];
 
 function convertToJSDate(year: number, month: number, date: number) {
-  return new Date(year, month-1, date);
+  return new Date(year, month - 1, date);
 }

--- a/main-site/lib/types.ts
+++ b/main-site/lib/types.ts
@@ -14,8 +14,10 @@ export interface FaqItemProps {
 export type SectionData = AboutSectionData;
 
 export interface AboutSectionData {
+  id: number
   title: string;
   description: string;
+  image: string;
 }
 
 export interface LandingSectionProps {

--- a/main-site/lib/utils.ts
+++ b/main-site/lib/utils.ts
@@ -1,5 +1,3 @@
-import { TestimonialData } from './types';
-
 export function getLeftOrRight<T>(
   direction: string,
   sectionData: T[],
@@ -22,28 +20,27 @@ export function getLeftOrRight<T>(
   return currItem;
 }
 
-export function getLeftOrRightTestimonial(
-  side: string,
-  testimonialData: TestimonialData[],
+// TO DO: Can refactor this and the above function into one. Avoiding for sake of speed
+export function getLeftOrRightCarouselData<CarouselData>(
+  side: "left" | "right",
+  carouselData: CarouselData[],
   currentIndex: number
-): TestimonialData {
-  const testimonialDatalength = testimonialData.length;
-  if (side == 'left') {
-    if (currentIndex == 0) {
-      return testimonialData[testimonialDatalength - 1];
+): CarouselData {
+  const carouselDataLength = carouselData.length;
+
+  if (side === "left") {
+    if (currentIndex === 0) {
+      return carouselData[carouselDataLength - 1];
     } else {
-      return testimonialData[currentIndex - 1];
+      return carouselData[currentIndex - 1];
+    }
+  } else {
+    if (currentIndex === carouselDataLength - 1) {
+      return carouselData[0];
+    } else {
+      return carouselData[currentIndex + 1];
     }
   }
 
-
-  if (side == 'right') {
-    if (currentIndex == testimonialDatalength - 1) {
-      return testimonialData[0];
-    } else {
-      return testimonialData[currentIndex + 1];
-    }
-  }
-  return testimonialData[currentIndex];
+  return carouselData[currentIndex];
 }
-

--- a/main-site/lib/utils.ts
+++ b/main-site/lib/utils.ts
@@ -28,10 +28,9 @@ export function getLeftOrRightTestimonial(
   currentIndex: number
 ): TestimonialData {
   const testimonialDatalength = testimonialData.length;
-  console.log(testimonialDatalength);
   if (side == 'left') {
     if (currentIndex == 0) {
-      return testimonialData[testimonialDatalength - 2];
+      return testimonialData[testimonialDatalength - 1];
     } else {
       return testimonialData[currentIndex - 1];
     }
@@ -40,7 +39,7 @@ export function getLeftOrRightTestimonial(
 
   if (side == 'right') {
     if (currentIndex == testimonialDatalength - 1) {
-      return testimonialData[currentIndex - 2];
+      return testimonialData[0];
     } else {
       return testimonialData[currentIndex + 1];
     }


### PR DESCRIPTION
Fixes carousel about section for mobile to have the right images left current and image 

Notes 
- Added a generic carousel left right get function that is type agnostic. 
- Added strict union type for direction "left" or "right" 
- Added index and image to the `AboutData` to mirror `TestimonialData`. (we should enforce this for all carousel data. refactor todo maybe @mike10911 ) 

![Screenshot 2023-11-04 at 11 45 58 PM](https://github.com/HackBeanpot/mono-repo/assets/65351416/c85e7603-bb32-48e7-9f75-d7a8db0edb35)

https://github.com/HackBeanpot/mono-repo/assets/65351416/aec70bc8-4f7d-45a0-b87f-ae68fab71159







