### PR TITLE
Bugfix: Past project description text

### DIFF
--- a/main-site/components/past-projects-section/PastProjectsSection.styles.ts
+++ b/main-site/components/past-projects-section/PastProjectsSection.styles.ts
@@ -122,9 +122,9 @@ const StyledPastProjectsDescription = styled(P)`
 
   @media ${max.tablet} {
     color: ${colors.WHITE};
-    margin-left: 5em;
-    margin-right: 5em;
-    text-align: left;
+    margin-left: 10%;
+    margin-right: 10%;
+    text-align: center;
     padding-bottom: 2em;
     letter-spacing: 0.5px;
   }


### PR DESCRIPTION
Fixes #290

Changelist:

- center past projects description text
- make text box scale with screen size

Screenshots & Screencasts:

https://github.com/HackBeanpot/mono-repo/assets/82426237/fb77e238-6ea2-4467-965f-9e2d20e7dd82


