### PR TITLE
Making sure the shell images in the About section update in mobile view

### DIFF
--- a/main-site/components/about-section/AboutSection.tsx
+++ b/main-site/components/about-section/AboutSection.tsx
@@ -23,7 +23,6 @@ import Growth from '../../../shared-ui/images/growthShell.png';
 import { AboutSectionData } from '../../lib/types';
 import Arrow from '../../../shared-ui/components/arrow/Arrow';
 import { getLeftOrRight } from '../../lib/utils';
-import Shell from '../../../shared-ui/images/shell.png';
 
 function getImage(title: string): string {
   if (title === 'Community') {
@@ -47,9 +46,13 @@ const AboutSection: React.FC = () => {
         <StyledTitle>HackBeanpot is about...</StyledTitle>
         {!isDesktop && (
           <StyledItemsContainer>
-            <StyledLeftImage src={Community} />
+            <StyledLeftImage
+              src={getImage(
+                getLeftOrRight('left', aboutSectionData, currItem).title
+              )}
+            />
             <StyledItemContainer>
-              <StyledCenterImage src={Exploration} />
+              <StyledCenterImage src={getImage(currItem.title)} />
               <StyledItemTextContainer>
                 <StyledItemTitle color={colors.WHITE}>
                   {currItem.title}
@@ -78,7 +81,11 @@ const AboutSection: React.FC = () => {
                 </StyledArrowDescriptionContainer>
               </StyledItemTextContainer>
             </StyledItemContainer>
-            <StyledRightImage src={Growth} />
+            <StyledRightImage
+              src={getImage(
+                getLeftOrRight('right', aboutSectionData, currItem).title
+              )}
+            />
           </StyledItemsContainer>
         )}
 

--- a/main-site/components/sponsor-us-page/sponsor-landing-page/SponsorLandingPage.tsx
+++ b/main-site/components/sponsor-us-page/sponsor-landing-page/SponsorLandingPage.tsx
@@ -14,16 +14,16 @@ import Sun from "../../../../shared-ui/images/sun.svg";
 import Moon from '../../../../shared-ui/images/moon.svg';
 import { moonRock, sunRays } from '../../landing-section/LandingSection.animations';
 import { SponsorUsLandingProps } from '../../../lib/types';
-import { StyledStar } from '../../landing-section/LandingSection.styles';
+// import { StyledStar } from '../../landing-section/LandingSection.styles';
 
 const SponsorUsLanding: React.FC<SponsorUsLandingProps> = ({ isDay, setIsDay }) => {
   return (
     <StyledContainer>
-      {isDay ? (
+      {/* {isDay ? (
         <StyledStar animate="animate" variants={sunRays} src={Sun} />
       ) : (
         <StyledStar animate="animate" variants={moonRock} src={Moon} />
-      )}
+      )} */}
       <StyledSponsorUsSectionContainer>
         <StyledSponsorUsHeader>
           <b>Sponsor Us</b>


### PR DESCRIPTION
Made left and right images in mobile view update according to arrow clicks

Fixes #312 

Changelist:
- I think merging accidentally deleted my work - so I re-added the conditions that update the left and right images

Screenshots & Screencasts:
<img width="493" alt="Screenshot 2023-11-07 at 12 45 42 AM" src="https://github.com/HackBeanpot/mono-repo/assets/52469441/433fe998-d74f-473d-8f58-c160e042f09e">

<img width="491" alt="Screenshot 2023-11-07 at 12 45 51 AM" src="https://github.com/HackBeanpot/mono-repo/assets/52469441/56fdbca2-bac9-4e5a-a919-bb03b22a5c4f">

<img width="496" alt="Screenshot 2023-11-07 at 12 45 59 AM" src="https://github.com/HackBeanpot/mono-repo/assets/52469441/54e5b97d-a30d-46a4-a06d-59c27a527acf">

