### PR TITLE
[Bug] Sponsor Section Title

### DIFF
--- a/main-site/components/sponsors-section/SponsorsSection.styles.ts
+++ b/main-site/components/sponsors-section/SponsorsSection.styles.ts
@@ -11,7 +11,11 @@ const StyledSponsorsSectionContainer = styled.div`
 `;
 
 const StyledSponsorsHeader = styled(H2)`
-  margin: 1em 0;
+  margin: 1em;
+
+  @media ${max.tablet} {
+    margin: 0.75em;
+  }
 `;
 
 const StyledContactText = styled(H4)`


### PR DESCRIPTION
Adjusted margins for sponsor section title so it is not at the edges of the screen

Fixes #295 

Changelist:
- updated the font em on `StyledSponsorsHeader` to increase margin on small screen sizes

Notes:
- Reviewed in person by @Aaryan1203 and @kzeng24 

Tested:
- localhost

Screenshots & Screencasts:
<img width="499" alt="Screenshot 2023-11-13 at 8 25 25 PM" src="https://github.com/HackBeanpot/mono-repo/assets/120346417/e3263546-1d66-474c-8f7b-94eb7c7e1dfe">