### PR TITLE
Fixed Clam Covering Text

### DIFF
--- a/main-site/components/adventure-ahead-section/AdventureAheadSection.styles.ts
+++ b/main-site/components/adventure-ahead-section/AdventureAheadSection.styles.ts
@@ -5,7 +5,7 @@ import { colors } from '../../../shared-ui/style/colors';
 
 const StyledAdventureAheadSectionContainer = styled.div`
   display: flex;
-  
+
   @media ${max.tablet} {
     margin: 10em 0;
     flex-wrap: wrap;
@@ -36,9 +36,11 @@ const StyledParagraph = styled(P)`
 `;
 
 const StyledImageCore = styled.img`
-  width: 40%;  
+  width: 40%;
   margin: auto;
   margin-left: 2em;
+  padding-top: 1em;
+  padding-bottom: 1em;
 
   @media ${max.tablet} {
     width: 80%;


### PR DESCRIPTION
Added padding around image so clam does not cover text in mobile view

Fixes #296 

<img width="549" alt="Screenshot 2024-01-19 at 11 35 55 AM" src="https://github.com/HackBeanpot/mono-repo/assets/52469441/e6646a5a-ad03-4e90-b0cb-78485897197d">


