### PR TITLE
Added styling and responsiveness to NoUpcoming

### DIFF
--- a/live-site/components/coming-up/no-upcoming/NoUpcoming.styles.tsx
+++ b/live-site/components/coming-up/no-upcoming/NoUpcoming.styles.tsx
@@ -3,15 +3,29 @@ import { max } from '../../../../shared-ui/lib/responsive';
 import { colors } from '../../../../shared-ui/style/colors';
 import { H2 } from '../../../../shared-ui/style/typography';
 
+
+
 const NoUpcomingContainer = styled.div`
+  border-radius: 2em;
+  background-color: ${colors.YELLOW_GREEN};
+  padding: 5em 0 5em 0;
+  width: 60%;
   text-align: center;
-  padding-top: 20em;
-  padding-bottom: 15em;
+  margin: 10em auto 0;
+
+  @media ${max.tabletLg} {
+        width: 80%;
+        padding: 5em 0 5em 0;
+      }
+      @media ${max.tablet} {
+        border-radius: 1.3em;
+        width: 90%;
+      }
 `;
 
 const StyledH2 = styled(H2)`
   letter-spacing: 0.01em;
-  font-size: 2.5em;
+  font-size: 2em;
   color: ${colors.TEXT_BROWN};
   @media ${max.tablet} {
     font-size: 2em;

--- a/live-site/components/coming-up/no-upcoming/NoUpcoming.styles.tsx
+++ b/live-site/components/coming-up/no-upcoming/NoUpcoming.styles.tsx
@@ -26,7 +26,7 @@ const NoUpcomingContainer = styled.div`
 const StyledH2 = styled(H2)`
   letter-spacing: 0.01em;
   font-size: 2em;
-  color: ${colors.TEXT_BROWN};
+  color: ${colors.TEXT_BOX_BLUE};
   @media ${max.tablet} {
     font-size: 2em;
   }

--- a/live-site/components/coming-up/no-upcoming/NoUpcoming.tsx
+++ b/live-site/components/coming-up/no-upcoming/NoUpcoming.tsx
@@ -4,7 +4,7 @@ import { NoUpcomingContainer, StyledH2 } from './NoUpcoming.styles';
 const NoUpcoming: React.FC = () => {
   return (
     <NoUpcomingContainer>
-      <StyledH2>Events Coming Soon!</StyledH2>
+      <StyledH2>No upcoming events!</StyledH2>
     </NoUpcomingContainer>
   );
 };

--- a/live-site/components/coming-up/no-upcoming/NoUpcoming.tsx
+++ b/live-site/components/coming-up/no-upcoming/NoUpcoming.tsx
@@ -4,7 +4,7 @@ import { NoUpcomingContainer, StyledH2 } from './NoUpcoming.styles';
 const NoUpcoming: React.FC = () => {
   return (
     <NoUpcomingContainer>
-      <StyledH2>No upcoming events!</StyledH2>
+      <StyledH2>Events Coming Soon!</StyledH2>
     </NoUpcomingContainer>
   );
 };


### PR DESCRIPTION
# Added styling and responsiveness to NoUpcoming

## 🎫 Issue #378 

### ▶ Changelist:

- Added background to the text
- Ensured responsiveness
- Changed color of the text
- Added some top margin


### 🎥 Screenshots & Screencasts:

<img width="1512" alt="Screenshot 2024-06-02 at 5 35 11 PM" src="https://github.com/HackBeanpot/mono-repo/assets/75456756/617b94f2-3ed4-489b-9b77-a908acc3d63a">

<img width="494" alt="Screenshot 2024-06-02 at 5 35 32 PM" src="https://github.com/HackBeanpot/mono-repo/assets/75456756/b7be9aa3-08f5-4bda-a77c-ff76baa77bfe">
